### PR TITLE
Update API to better match Mac::PropertyList

### DIFF
--- a/lib/Mac/PropertyList/SAX.pm
+++ b/lib/Mac/PropertyList/SAX.pm
@@ -191,7 +191,9 @@ sub _parse {
         goto $delegate;
     } else {
         my $handler = Mac::PropertyList::SAX::Handler->new;
-        XML::SAX::ParserFactory->parser(Handler => $handler)->$sub($data);
+        eval {
+            XML::SAX::ParserFactory->parser(Handler => $handler)->$sub($data);
+        } or die "doesn't look like a valid plist: $@";
 
         return $handler->{struct};
     }

--- a/lib/Mac/PropertyList/SAX.pm
+++ b/lib/Mac/PropertyList/SAX.pm
@@ -538,7 +538,7 @@ L<Mac::PropertyList|Mac::PropertyList>, the inspiration for this module.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2007-2017 by Darren Kulp
+Copyright (C) 2007-2022 by Darren Kulp
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.4 or,

--- a/lib/Mac/PropertyList/SAX.pm
+++ b/lib/Mac/PropertyList/SAX.pm
@@ -441,6 +441,8 @@ sub write { $_[0]->Mac::PropertyList::SAX::Scalar::write }
 use overload '""' => sub { $_[0]->as_basic_data };
 package Mac::PropertyList::SAX::data;
 use base qw(Mac::PropertyList::data Mac::PropertyList::SAX::Scalar);
+package Mac::PropertyList::SAX::uid;
+use base qw(Mac::PropertyList::uid Mac::PropertyList::SAX::Scalar);
 package Mac::PropertyList::SAX::Boolean;
 use Object::MultiType;
 use base qw(Mac::PropertyList::Boolean Object::MultiType);

--- a/lib/Mac/PropertyList/SAX.pm
+++ b/lib/Mac/PropertyList/SAX.pm
@@ -198,6 +198,17 @@ sub _parse {
     }
 }
 
+=item create_from( HASH_REF | ARRAY_REF | STRING )
+
+Dispatches to C<create_from_ref> or C<create_from_string> depending on the type of the argument.
+
+=cut
+
+sub create_from {
+    my $sub = ref $_[0] && \&create_from_ref || \&create_from_string;
+    return &$sub;
+}
+
 =item create_from_ref( HASH_REF | ARRAY_REF )
 
 Create a plist from an array or hash reference.

--- a/lib/Mac/PropertyList/SAX.pm
+++ b/lib/Mac/PropertyList/SAX.pm
@@ -37,7 +37,6 @@ C<$XML::SAX::ParserPackage> directly).
 use strict;
 use warnings;
 
-use Carp qw(carp);
 use HTML::Entities qw(encode_entities_numeric);
 use HTML::Entities::Numbered qw(hex2name name2hex_xml);
 # Passthrough function
@@ -131,7 +130,7 @@ sub parse_plist_file {
     if (ref $file) {
         parse_plist_fh($file);
     } else {
-        carp("parse_plist_file: file [$file] does not exist!"), return unless -e $file;
+        die "parse_plist_file: file [$file] does not exist!" unless -e $file;
         _parse("parse_uri", $file);
     }
 }

--- a/t/create_from_ref.t
+++ b/t/create_from_ref.t
@@ -1,6 +1,6 @@
 # Stolen from Mac::PropertyList (by comdog) for use in Mac::PropertyList::SAX (by kulp)
 
-use Test::More tests => 1;
+use Test::More tests => 4;
 
 use Mac::PropertyList::SAX;
 
@@ -23,3 +23,11 @@ my $parsed = Mac::PropertyList::SAX::parse_plist_string($string);
 
 is_deeply($parsed, $structure, "recursive serialization / deserialization");
 
+my $str2 = Mac::PropertyList::SAX::create_from($structure);
+is($string, $str2, "create_from dispatches a ref");
+my $p2 = Mac::PropertyList::SAX::parse_plist($str2);
+is_deeply($p2, $structure, "dispatched serialization / deserialization");
+
+my $string_only = Mac::PropertyList::SAX::create_from("hello, world");
+my $expected = Mac::PropertyList::create_from_string("hello, world");
+is($string_only, $expected);

--- a/t/parse_plist_file.t
+++ b/t/parse_plist_file.t
@@ -67,9 +67,9 @@ test_plist( $plist );
 my $filename;
 1 while ($filename = 1 + rand(100000) and -e $filename);
 
-my $plist = parse_plist_file( $filename );
+my $plist = eval { parse_plist_file( $filename ) };
 
-ok( !$plist, "return value is false for missing file" );
+ok( length $@, "parse_plist_file dies for missing file" );
 }
 
 


### PR DESCRIPTION
These changes reconverge the API of `Mac::PropertyList::SAX` to that of `Mac::PropertyList`. A subsequent PR will update the tests to more clearly demonstrate this, by adopting ([with permission][1]) the test suite of `Mac::PropertyList` explicitly.

Each commit in the current PR passes `prove -l`.

[1]: https://github.com/briandfoy/mac-propertylist/issues/11#issuecomment-1168181132