### PR TITLE
Introduce a simple performance comparison script

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,6 +1,7 @@
 .cvsignore
 Changes
 CONTRIBUTING
+extra/benchmark.sh
 inc/Module/AutoInstall.pm
 inc/Module/Install.pm
 inc/Module/Install/AutoInstall.pm

--- a/extra/benchmark.sh
+++ b/extra/benchmark.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Compare real-time parsing speeds between multiple Perl modules providing the
+# `Mac::PropertyList::parse_plist_file` interface.
+
+# Fail earl and loudly.
+set -o errexit -o nounset -o pipefail
+
+plists=( "$@" )
+
+modules=(
+    Mac::PropertyList
+    Mac::PropertyList::SAX
+)
+
+real_seconds () { command time -p "$@" 2>&1 >/dev/null | grep ^real | (read _ x; echo $x); }
+
+echo -e "plist\tbytes\tmodule\tseconds"
+for p in "${plists[@]}"
+do
+    bytes=$(stat -f %z "$p")
+    for mod in "${modules[@]}"
+    do
+        echo -ne "$p\t$bytes\t$mod\t"
+        real_seconds perl -Mlib=lib -M$mod=parse_plist_file -e 'parse_plist_file(@ARGV)' "$p"
+    done
+done


### PR DESCRIPTION
Closes #7.

The speedup provided by `Mac::PropertyList::SAX` is highly dependent upon the structure of the data: deeply-nested structures seem generally to gain a lot more from `::SAX` than shallow structures do.

For sufficiently small, flat files (a up to a few dozen kilobytes in size from the samples used below), `Mac::PropertyList` can be faster than `Mac::PropertyList::SAX` (particularly when the total parse time is under about 0.1 seconds).

For sufficiently large files (up to a few megabytes), `::SAX` seems to pull ahead by a speedup factor of about 3x-10x.

<details>

```
$ ./extra/benchmark.sh /System/Library/AssetsV2/com_apple_MobileAsset_*/*/AssetData/**/*.plist | tee raw | sort -grk2 | head -n20 | column -s$'\t' -t | tee columns
/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/2766126fea7d22f95f86a2064d05838a8724587b.asset/AssetData/boot/BuildManifest.plist    2210128  Mac::PropertyList::SAX  0.89
/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/2766126fea7d22f95f86a2064d05838a8724587b.asset/AssetData/boot/BuildManifest.plist    2210128  Mac::PropertyList       6.20
/System/Library/AssetsV2/com_apple_MobileAsset_SFRSoftwareUpdate/e90cd549c06d8dd2acc373db901e892f6f78ed24.asset/AssetData/boot/BuildManifest.plist    1734135  Mac::PropertyList::SAX  0.73
/System/Library/AssetsV2/com_apple_MobileAsset_SFRSoftwareUpdate/e90cd549c06d8dd2acc373db901e892f6f78ed24.asset/AssetData/boot/BuildManifest.plist    1734135  Mac::PropertyList       2.97
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/57dfe54591169394d709a70c6875765df82226bd.asset/AssetData/parser/cfg.plist               478528   Mac::PropertyList::SAX  0.22
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/57dfe54591169394d709a70c6875765df82226bd.asset/AssetData/parser/cfg.plist               478528   Mac::PropertyList       0.72
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/bfb69e4913d0556f027e5628566fa18f74b3e668.asset/AssetData/parser/cfg.plist               457655   Mac::PropertyList::SAX  0.21
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/bfb69e4913d0556f027e5628566fa18f74b3e668.asset/AssetData/parser/cfg.plist               457655   Mac::PropertyList       0.64
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/c55ebecca7037d50a22fe39315a802984688c69f.asset/AssetData/parser/cfg.plist               457422   Mac::PropertyList::SAX  0.21
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/c55ebecca7037d50a22fe39315a802984688c69f.asset/AssetData/parser/cfg.plist               457422   Mac::PropertyList       0.67
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/372d2ed36fafdcd456d1d9bced7acded5326c5f7.asset/AssetData/parser/cfg.plist               456794   Mac::PropertyList::SAX  0.21
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/372d2ed36fafdcd456d1d9bced7acded5326c5f7.asset/AssetData/parser/cfg.plist               456794   Mac::PropertyList       0.66
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/284d956d0dc75861a93e4586675a257c72989279.asset/AssetData/parser/cfg.plist               453823   Mac::PropertyList::SAX  0.22
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/284d956d0dc75861a93e4586675a257c72989279.asset/AssetData/parser/cfg.plist               453823   Mac::PropertyList       0.65
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/57dfe54591169394d709a70c6875765df82226bd.asset/AssetData/parser/dates.plist             274680   Mac::PropertyList::SAX  0.12
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/57dfe54591169394d709a70c6875765df82226bd.asset/AssetData/parser/dates.plist             274680   Mac::PropertyList       1.10
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/bfb69e4913d0556f027e5628566fa18f74b3e668.asset/AssetData/parser/dates.plist             127396   Mac::PropertyList::SAX  0.07
/System/Library/AssetsV2/com_apple_MobileAsset_LinguisticData/bfb69e4913d0556f027e5628566fa18f74b3e668.asset/AssetData/parser/dates.plist             127396   Mac::PropertyList       0.43
/System/Library/AssetsV2/com_apple_MobileAsset_SpeechTranslationAssets3/4a7201ce988ed3828d368572f24abfd5727eb3ff.asset/AssetData/Configuration.plist  109482   Mac::PropertyList::SAX  0.06
/System/Library/AssetsV2/com_apple_MobileAsset_SpeechTranslationAssets3/4a7201ce988ed3828d368572f24abfd5727eb3ff.asset/AssetData/Configuration.plist  109482   Mac::PropertyList       0.06
```
</details>
