### PR TITLE
Tell github-linguist that all .t files are Perl (not Raku)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes
+*.t linguist-language=Perl


### PR DESCRIPTION
I noticed that GitHub guessed wrong on some .t files and thinks you have some Raku in here. The .gitattributes file can give github-linguist some hints.